### PR TITLE
fix: book not being generated

### DIFF
--- a/.github/workflows/mdbook.yaml
+++ b/.github/workflows/mdbook.yaml
@@ -35,7 +35,7 @@ jobs:
             - name: Upload artifact
               uses: actions/upload-pages-artifact@v1
               with:
-                  path: ./book
+                  path: ./book/html
 
     deploy:
         environment:

--- a/book.toml
+++ b/book.toml
@@ -5,4 +5,6 @@ multilingual = false
 src = "src"
 title = "Cat sitting for beginners"
 
+[output.html]
+
 [output.linkcheck]


### PR DESCRIPTION
Book location was empty after running `mdbook build`, because adding the `linkcheck` renderer caused it to not generate the book.
Fix was to include html output and and adjust the path, as it's now generated in `./book/html` instead of `./html`